### PR TITLE
Issue #3008: Change Zen.CI to use a Symlink for the entire web root

### DIFF
--- a/core/misc/zen-ci/init_test.sh
+++ b/core/misc/zen-ci/init_test.sh
@@ -7,23 +7,14 @@
 # https://github.com/backdrop-ops/backdropcms.org/tree/master/www/modules/custom/borg_qa
 ##
 
-#set site path
+# Set site path variable.
 SITEPATH="$HOME/www"
 
-# Go to domain directory.
-cd $SITEPATH
+# Remove the old site path.
+rm -rf $SITEPATH
 
-# Link Backdrop files
-ln -s $GITLC_DEPLOY_DIR/* ./
-ln -s $GITLC_DEPLOY_DIR/.htaccess ./
-
-# Unlink settings.php and copy instead.
-rm -f settings.php
-cp $GITLC_DEPLOY_DIR/settings.php ./
-
-# Unlink files and copy instead.
-rm -f files
-cp -r $GITLC_DEPLOY_DIR/files ./
+# Link to the git checkout.
+ln -s $GITLC_DEPLOY_DIR $SITEPATH
 
 # Install Backdrop.
 php $SITEPATH/core/scripts/install.sh  --db-url=mysql://test:@localhost/test --root=/home/test/www


### PR DESCRIPTION
I found that tests pass with the changes suggested in https://github.com/backdrop/backdrop/pull/3682 if we use a single symlink for the entire web root instead of a symlink for each directory.
